### PR TITLE
Document one-to-many relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ACME API is a Spring Boot application that provides RESTful endpoints for managing Widgets and Doodads for ACME Corporation.
 
+Widgets and Doodads share a **one-to-many** relationship: a single widget can contain multiple doodads.
+
 ## Prerequisites
 
 - Java 21 or higher

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,6 +4,7 @@ info:
   title: ACME API
   description: |
     ACME Corporation API for Widgets and Doodads.
+    Widgets can contain multiple doodads, forming a one-to-many relationship.
   version: 1.0.0
 
 servers:


### PR DESCRIPTION
## Summary
- note that widgets can contain multiple doodads in README
- update OpenAPI description with the new relationship

## Testing
- `./gradlew test` *(fails: NoRouteToHostException downloading gradle)*